### PR TITLE
Alter array element formatting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ module.exports = {
         'no-restricted-modules': 'error',
         'array-bracket-newline': 'error',
         'array-bracket-spacing': 'error',
-        'array-element-newline': 'error',
+        'array-element-newline': ['error', { "multiline": true }],
         'block-spacing': 'error',
         'brace-style': 'error',
         'camelcase': 'error',


### PR DESCRIPTION
Force array elements to be in their own lines only if the array is multiline in the first place.